### PR TITLE
fix: correct listmonk role from core team to contributor

### DIFF
--- a/content/projects/starred/listmonk/index.md
+++ b/content/projects/starred/listmonk/index.md
@@ -6,7 +6,7 @@ weight = 1
 [extra]
 github_url = "https://github.com/knadh/listmonk"
 website_url = "https://listmonk.app"
-context = "Core team member. Contributed email templating, campaign features, and various improvements."
+context = "Contributor. Contributed email templating, campaign features, and various improvements."
 +++
 
 listmonk is a standalone, self-hosted, newsletter and mailing list manager. It is fast, feature-rich, and packed into a single binary.


### PR DESCRIPTION
Updates the listmonk project description to accurately reflect contributor status rather than core team member.

Kailash created listmonk - this corrects the role description.