### PR TITLE
docs: add simples3 S3 Files note

### DIFF
--- a/content/pages/go/_index.md
+++ b/content/pages/go/_index.md
@@ -17,6 +17,8 @@ Notes on Go patterns and internals that came up during real work. Testing idioms
 
 [Go Testing Patterns](@/pages/go/testing-patterns.md). The `if got, want :=` idiom and table-driven tests.
 
+[AWS S3 Files and simples3](@/pages/go/aws-s3-files-and-simples3.md). Why I decided not to add S3 Files support to the core library.
+
 [Singleflight for a Go Cache Library](@/pages/go/singleflight.md). Deduplicating concurrent cache fills with `sync/singleflight`.
 
 [Go ASM R15 Clobbered in Plugin Buildmode](@/pages/go/asm-r15-plugin-clobber.md). Debugging an assembly register clobber caused by `-buildmode=plugin`.

--- a/content/pages/go/aws-s3-files-and-simples3.md
+++ b/content/pages/go/aws-s3-files-and-simples3.md
@@ -1,0 +1,75 @@
++++
+title = "AWS S3 Files and simples3"
+description = "Notes on why AWS S3 Files is out of scope for the core simples3 library."
+weight = 2
+template = "pages-page.html"
+date = 2026-04-13
+draft = false
+
+[extra]
+section_title = "Go"
++++
+
+This is a note about a feature I decided not to add.
+
+I looked into [AWS S3 Files](https://aws.amazon.com/s3/features/files/) because it sounded like something [simples3](@/pages/projects/simples3/index.md) might eventually support. It has S3 in the name, it works with S3 data, and at first glance it feels close enough to be relevant.
+
+After reading through the docs, CLI, and SDK surface, I came away with a pretty clear conclusion: `simples3` should not add S3 Files support to the core library.
+
+## Why I am not adding it
+
+The short answer is that S3 Files is not just "more S3 object API."
+
+A few signs show that immediately:
+
+- the CLI is `aws s3files`, not `aws s3api`
+- the Go SDK has a separate `service/s3files` package
+- the API is built around management calls like `CreateFileSystem` and `CreateMountTarget`
+
+That matters because `simples3` is deliberately narrow. It is a small S3 object and bucket client. People use it for things like:
+
+- upload and download
+- list and delete
+- bucket operations
+- presigned URLs
+- talking to S3-compatible endpoints without dragging in the full AWS SDK
+
+S3 Files pulls the conversation somewhere else entirely:
+
+- file systems and mount targets
+- IAM roles and permissions
+- VPCs, subnets, and security groups
+- mount helpers and NFS access
+- AWS-only workflows
+
+Once those concerns show up, we are not really talking about a minimal object-storage library anymore.
+
+## This feels closer to Terraform/OpenTofu territory
+
+This was probably the biggest clue for me.
+
+If I wanted to automate S3 Files, my first instinct would not be to extend a small object client. I would expect that work to live in infrastructure tooling, or in the AWS SDK itself.
+
+S3 Files looks much more like something you provision and manage alongside IAM, networking, and mounts. That makes it feel closer to Terraform, OpenTofu, CloudFormation, or Pulumi than to a library whose main job is object operations.
+
+That does not make S3 Files uninteresting. It just puts it in a different category.
+
+## What this means in practice
+
+If a bucket is used by S3 Files, `simples3` can still talk to that bucket as a normal S3 bucket. That part is fine.
+
+What I do not want to imply is that `simples3` understands the S3 Files service itself, because it doesn't, and I do not think it should.
+
+S3 Files also brings its own rules and caveats around things like versioning, encryption, metadata, and ACL behavior. Those are real constraints, but they belong to the S3 Files layer, not inside the core of `simples3`.
+
+## Could there still be a Go package for it?
+
+Maybe. If I ever need lightweight S3 Files automation without the full AWS SDK, I would rather put that in a separate package, something like `simples3/s3files` or `simples3/x/s3files`.
+
+Even then, I would treat it as AWS-only control-plane code, not as an expansion of the main library.
+
+## Conclusion
+
+So this is really a scope decision.
+
+I would rather let `simples3` stay small and honest about what it is than stretch it into a different AWS product with a very different operational model.

--- a/content/pages/projects/simples3/index.md
+++ b/content/pages/projects/simples3/index.md
@@ -11,9 +11,13 @@ github_url = "https://github.com/rhnvrm/simples3"
 
 A Go library for manipulating objects in S3 buckets using REST API calls signed with AWS Signature Version 4. Used in production at [Zerodha](https://zerodha.tech).
 
+## Scope
+
+I looked into whether `simples3` should add support for AWS S3 Files. I decided not to put that into the core library. S3 Files is a separate AWS service with its own control plane and operational model, and it would pull `simples3` away from its main job: being a small S3 object client. I wrote up the reasoning here: [AWS S3 Files and simples3](@/pages/go/aws-s3-files-and-simples3.md).
+
 ## Why simples3?
 
-The official AWS Go SDK is massive. If all you need is basic S3 operations, pulling in 50+ MB of dependencies feels excessive. simples3 provides a minimal alternative with **zero dependencies** beyond the Go standard library.
+The official AWS Go SDK is massive. If all you need is basic S3 operations, pulling in a much larger dependency tree feels excessive. simples3 provides a minimal alternative with **zero dependencies** beyond the Go standard library.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- add a new Go note explaining why AWS S3 Files is out of scope for core simples3
- link the note from the Go section index
- add a short scope note to the simples3 project page

## Verification
- `just build`