### PR TITLE
feat(deploy): add s3site canary workflow

### DIFF
--- a/.github/workflows/deploy-s3site.yml
+++ b/.github/workflows/deploy-s3site.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
+          tags: tag:gh-ci
           ping: rhnvrm-private
 
       - name: Install AWS CLI

--- a/.github/workflows/deploy-s3site.yml
+++ b/.github/workflows/deploy-s3site.yml
@@ -1,0 +1,69 @@
+name: Deploy via s3site (canary)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-rohanverma-s3site
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build site
+        run: nix build .#default
+
+      - name: Create site archive
+        run: tar czf rohanverma.net.tar.gz -C result .
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          ping: rhnvrm-private
+
+      - name: Install AWS CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y awscli
+
+      - name: Upload archive to Garage
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3SITE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3SITE_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: garage
+          AWS_EC2_METADATA_DISABLED: true
+          S3SITE_BUCKET: static-sites
+          S3SITE_ENDPOINT: http://rhnvrm-private:3900
+        run: |
+          set -euo pipefail
+          aws --endpoint-url "${S3SITE_ENDPOINT}" s3 cp rohanverma.net.tar.gz "s3://${S3SITE_BUCKET}/sites/rohanverma.net.tar.gz"
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "${{ secrets.DEPLOY_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Refresh s3site on oddship-web
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=accept-new \
+            -o ServerAliveInterval=60 \
+            -o ServerAliveCountMax=10 \
+            rhnvrm@${{ secrets.DEPLOY_HOST }} \
+            "sudo /run/current-system/sw/bin/s3site refresh -socket /run/s3site/control.sock rohanverma.net && \
+             curl -fsS -H 'Host: rohanverma.net' http://127.0.0.1:9001/ >/dev/null"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,31 @@ zola build    # Build for production
 - `justfile` - Development task definitions
 - `ai/` - Project documentation
 
+## Deployment
+
+Production currently deploys through `oddship/nix-system`.
+
+A canary workflow for the future `s3site` path lives at:
+
+- `.github/workflows/deploy-s3site.yml`
+
+That workflow expects these GitHub secrets:
+
+- `TS_OAUTH_CLIENT_ID`
+- `TS_OAUTH_SECRET`
+- `S3SITE_ACCESS_KEY_ID`
+- `S3SITE_SECRET_ACCESS_KEY`
+- `DEPLOY_HOST`
+- `DEPLOY_SSH_KEY`
+
+It builds the site, joins the tailnet with the Tailscale GitHub Action, uploads `sites/rohanverma.net.tar.gz` to Garage at `http://rhnvrm-private:3900`, and then runs `sudo /run/current-system/sw/bin/s3site refresh` over SSH.
+
+Before using it, `oddship-web` must have:
+
+- the `s3site` service enabled
+- agenix-managed `oddship-web-s3site-env.age` with the Garage runtime credentials
+- agenix-managed `oddship-web-tailscale-auth.age` with `TAILSCALE_AUTH_KEY=...` so the host can join the tailnet and reach Garage privately
+
 ## License
 
 Content © Rohan Verma. Code is available under MIT license.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ A canary workflow for the future `s3site` path lives at:
 That workflow expects these GitHub secrets:
 
 - `TS_OAUTH_CLIENT_ID`
-- `TS_OAUTH_SECRET`
+- `TS_OAUTH_SECRET` (OAuth client must be allowed to use `tag:gh-ci`)
 - `S3SITE_ACCESS_KEY_ID`
 - `S3SITE_SECRET_ACCESS_KEY`
 - `DEPLOY_HOST`


### PR DESCRIPTION
## Summary
- add a manual canary workflow for uploading the built site to Garage via Tailscale
- refresh `oddship-web` over SSH with `sudo /run/current-system/sw/bin/s3site refresh`
- document the required GitHub secrets and agenix-backed host prerequisites

## Notes
- the matching `oddship/nix-system` canary plumbing is in PR #2
- the first canary attempt was rolled back because `oddship-web` needs a fresh Tailscale host auth key
